### PR TITLE
fix: parcel dependency and supported extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "jest": "^24.1.0",
     "linaria": "^1.1.4",
     "parcel-assert-bundle-tree": "^1.0.0",
-    "parcel-bundler": "^1.12.3",
+    "parcel": "^1.12.3",
     "parcel-plugin-linaria": "link:.",
     "prettier": "^1.16.4",
     "react": "^16.8.3",
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "linaria": ">= 1.0.0",
-    "parcel-bundler": ">= 1.12.0"
+    "parcel": ">= 1.12.0"
   },
   "husky": {
     "hooks": {

--- a/src/LinariaAsset.js
+++ b/src/LinariaAsset.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const Module = require('module');
-const JSAsset = require('parcel-bundler/src/assets/JSAsset');
+const JSAsset = require('parcel/src/assets/JSAsset');
 const transform = require('linaria/lib/transform');
 
 const RESULT = Symbol('linaria-transform-result');

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -1,4 +1,4 @@
-const Bundler = require('parcel-bundler');
+const Bundler = require('parcel');
 const assertBundleTree = require('parcel-assert-bundle-tree');
 const path = require('path');
 const LinariaPlugin = require('../index');

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,11 @@
 /* eslint-disable func-names */
 
 module.exports = function(bundler) {
-  bundler.addAssetType('js', require.resolve('./LinariaAsset'));
+  const LinariaAsset = require.resolve('./LinariaAsset');
+
+  bundler.addAssetType('js', LinariaAsset);
+  bundler.addAssetType('jsx', LinariaAsset);
+
+  bundler.addAssetType('ts', LinariaAsset);
+  bundler.addAssetType('tsx', LinariaAsset);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6545,10 +6545,14 @@ parcel-assert-bundle-tree@^1.0.0:
   resolved "https://registry.yarnpkg.com/parcel-assert-bundle-tree/-/parcel-assert-bundle-tree-1.0.0.tgz#d10a1bff6fb690cdbda5201cae216366c23c837e"
   integrity sha512-PpEArwgoZGRCDdHLxFpjs4Rl5X8dAL0SUQ8uqsXVSJMDmbSbha1P28X2kWaTu2RVfwSswv7MSF0NA/qzn0H/IA==
 
-parcel-bundler@^1.12.3:
+"parcel-plugin-linaria@link:./.":
+  version "0.0.0"
+  uid ""
+
+parcel@^1.12.3:
   version "1.12.3"
-  resolved "https://registry.yarnpkg.com/parcel-bundler/-/parcel-bundler-1.12.3.tgz#2bbf70bfa2d06097f071653285040bd125684d09"
-  integrity sha512-8bq6lj0hhQeGxD9f9xEkFMXQ3d8TIlf2+isKxoi9bciB0KVEILRGllaPkUgp++5t0anToBh9+tG6ZyInXOC1/A==
+  resolved "https://registry.yarnpkg.com/parcel/-/parcel-1.12.3.tgz#1f1341589380f20be924f1dd67c7fed193b346ec"
+  integrity sha512-j9XCVLeol9qZvGemRKt2z8bptbXq9LVy8/IzjqWQKMiKd8DR0NpDAlRHV0zyF72/J/UUTsdsrhnw6UGo9nGI+Q==
   dependencies:
     "@babel/code-frame" "^7.0.0 <7.4.0"
     "@babel/core" "^7.0.0 <7.4.0"
@@ -6607,9 +6611,6 @@ parcel-bundler@^1.12.3:
     terser "^3.7.3"
     v8-compile-cache "^2.0.0"
     ws "^5.1.1"
-
-"parcel-plugin-linaria@link:./.":
-  version "0.1.1"
 
 parent-module@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

- Move to `parcel` package instead of `parcel-bundler`
- Add jsx, tsx, ts to supported file extensions

Fixes #5 

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Check out #5 for test case

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
